### PR TITLE
Add GitHub Actions workflow for publishing common library to Maven Ce…

### DIFF
--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -1,0 +1,40 @@
+name: Publish Common Library to Maven Central
+
+on:
+  push:
+    branches: [ common ]
+    paths:
+      - 'common/**'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          server-id: central
+          settings-path: ${{ github.workspace }}
+      
+      - name: Configure GPG Key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" > private-key.asc
+          gpg --batch --import private-key.asc
+          gpg --list-secret-keys --keyid-format LONG
+          rm private-key.asc
+        
+      - name: Publish to Maven Central
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          cd common
+          mvn clean deploy -Prelease -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} --settings ${{ github.workspace }}/.github/workflows/settings.xml

--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${env.OSSRH_USERNAME}</username>
+      <password>${env.OSSRH_PASSWORD}</password>
+    </server>
+    <server>
+      <id>gpg.passphrase</id>
+      <passphrase>${env.GPG_PASSPHRASE}</passphrase>
+    </server>
+  </servers>
+</settings> 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -63,12 +63,14 @@
 
     <scm>
         <url>https://github.com/UmutGuzel/telecommunication-crm</url>
-        <connection>scm:git:git://github.com/UmutGuzel/telecommunication-crm</connection>
+        <connection>scm:git:git://github.com/UmutGuzel/telecommunication-crm.git</connection>
+        <developerConnection>scm:git:ssh://github.com:UmutGuzel/telecommunication-crm.git</developerConnection>
     </scm>
 
     <distributionManagement>
         <repository>
             <id>central</id>
+            <name>Maven Central</name>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
@@ -135,5 +137,74 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.6.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <tokenAuth>true</tokenAuth>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
…ntral

- Created a new workflow to automate the publishing of the common library upon pushes to the 'common' branch.
- Configured steps for checking out code, setting up JDK 21, importing GPG keys, and publishing artifacts to Maven Central.
- Added a settings.xml file for Maven server credentials and GPG passphrase.
- Updated pom.xml to include a release profile for artifact signing and source/javadoc attachment.